### PR TITLE
Integrated Jackson Mixins with the json converter

### DIFF
--- a/approval-json/src/main/java/com/github/approval/converters/JacksonJsonConverter.java
+++ b/approval-json/src/main/java/com/github/approval/converters/JacksonJsonConverter.java
@@ -35,16 +35,25 @@ import javax.annotation.Nonnull;
  */
 public final class JacksonJsonConverter<T> extends AbstractStringConverter<T> {
 
+    private static final JacksonJsonConverter SANE_DEFAULTS_INSTANCE = new JacksonJsonConverter(
+            new ObjectMapper()
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                    .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+    );
 
     private final ObjectMapper mapper;
+
 
     private JacksonJsonConverter(ObjectMapper mapper) {
         this.mapper = mapper;
     }
 
-
     /**
      * Gets a converter with sane defaults from jackson. The sane defaults are the following:
+     *
      * <ul>
      *     <li>format/indent the output</li>
      *     <li>write dates in a human readable format</li>
@@ -59,10 +68,9 @@ public final class JacksonJsonConverter<T> extends AbstractStringConverter<T> {
         return SANE_DEFAULTS_INSTANCE;
     }
 
-
-
     /**
      * Gets a converter for the specified object mapper instance.
+     *
      * @param objectMapper the object mapper that will be used
      * @param <T> the type of objects that will be converted
      * @return a converter for the specified mapper instance
@@ -71,15 +79,20 @@ public final class JacksonJsonConverter<T> extends AbstractStringConverter<T> {
         return new JacksonJsonConverter<T>(objectMapper);
     }
 
-
-
-    private static final JacksonJsonConverter SANE_DEFAULTS_INSTANCE = new JacksonJsonConverter(
-            new ObjectMapper()
-                .enable(SerializationFeature.INDENT_OUTPUT)
-                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    );
+    /**
+     * Integrates a special Jackson mixin entity which modifies the json representation of your
+     * entity through Jackson Annotations without actually touching it.
+     *
+     * @param entityClass class object of the entity you want to represent in json form.
+     * @param mixinClass  class object representing the standard Jackson Mixin which offers an indirect way
+     *                    to add annotations to ignore or do something else with the members
+     *                    of the entity you want to serialize without actually touching it.
+     *                    Learn more at: {@linktourl http://wiki.fasterxml.com/JacksonMixInAnnotations}
+     * @return same instance of converter for the specified mapper instance
+     */
+    public void withJacksonMixin(Class<?> entityClass, Class<?> mixinClass) {
+        mapper.addMixInAnnotations(entityClass, mixinClass);
+    }
 
     @Nonnull
     @Override

--- a/approval-json/src/test/java/com/github/approval/converters/EntityMixin1.java
+++ b/approval-json/src/test/java/com/github/approval/converters/EntityMixin1.java
@@ -1,5 +1,4 @@
 package com.github.approval.converters;
-
 /*
  * #%L
  * com.github.nikolavp:approval-json
@@ -9,9 +8,9 @@ package com.github.approval.converters;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,36 +19,28 @@ package com.github.approval.converters;
  * #L%
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.Date;
 
 /**
- * User: nikolavp (Nikola Petrov) Date: 14-9-1 Time: 17:12
+ * This class is a standard jackson mixin which offers an indirect way
+ * to add annotations to ignore or do something else with the members
+ * of the entity you want to serialize without actually touching it.
+ *
+ * This mixin simply ignores date, age and first name which
+ * we do not want to test of the Entity object!
+ *
+ * Learn more at: {@linktourl http://wiki.fasterxml.com/JacksonMixInAnnotations}
+ *
+ *
+ * @author Tsvetan Dimitrov <tsvetan.dimitrov@gmail.com>
  */
-public class Entity {
+public abstract class EntityMixin1 {
 
-    Date date;
-    String firstName;
-    String lastName;
-    int age;
-    String homeTown;
+    @JsonIgnore abstract Date getDate();
 
-    public String getFirstName() {
-        return firstName;
-    }
+    @JsonIgnore abstract int getAge();
 
-    public String getLastName() {
-        return lastName;
-    }
-
-    public int getAge() {
-        return age;
-    }
-
-    public String getHomeTown() {
-        return homeTown;
-    }
-
-    public Date getDate() {
-        return date;
-    }
+    @JsonIgnore abstract String getFirstName();
 }

--- a/approval-json/src/test/java/com/github/approval/converters/EntityMixin2.java
+++ b/approval-json/src/test/java/com/github/approval/converters/EntityMixin2.java
@@ -1,5 +1,4 @@
 package com.github.approval.converters;
-
 /*
  * #%L
  * com.github.nikolavp:approval-json
@@ -9,9 +8,9 @@ package com.github.approval.converters;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,36 +19,24 @@ package com.github.approval.converters;
  * #L%
  */
 
-import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
- * User: nikolavp (Nikola Petrov) Date: 14-9-1 Time: 17:12
+ * This class is a standard jackson mixin which offers an indirect way
+ * to add annotations to ignore or do something else with the members
+ * of the entity you want to serialize without actually touching it.
+ *
+ * This mixin simply ignores last name and hometown  which
+ * we do not want to test of the Entity object!
+ *
+ * Learn more at: {@linktourl http://wiki.fasterxml.com/JacksonMixInAnnotations}
+ *
+ *
+ * @author Tsvetan Dimitrov <tsvetan.dimitrov@gmail.com>
  */
-public class Entity {
+public abstract class EntityMixin2 {
 
-    Date date;
-    String firstName;
-    String lastName;
-    int age;
-    String homeTown;
+    @JsonIgnore abstract String getLastName();
 
-    public String getFirstName() {
-        return firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public int getAge() {
-        return age;
-    }
-
-    public String getHomeTown() {
-        return homeTown;
-    }
-
-    public Date getDate() {
-        return date;
-    }
+    @JsonIgnore abstract String getHomeTown();
 }

--- a/approval-json/src/test/java/com/github/approval/converters/JacksonJsonConverterTest.java
+++ b/approval-json/src/test/java/com/github/approval/converters/JacksonJsonConverterTest.java
@@ -39,18 +39,25 @@ public class JacksonJsonConverterTest {
         entity = new Entity();
         entity.age = 10;
         entity.date = new Date(0);
+        entity.firstName = "Tom";
+        entity.lastName = "Smith";
+        entity.homeTown = "Washington";
     }
 
     @Test
-    public void shouldCreateProperSerilazireWithSaneDefaults() throws Exception {
+    public void shouldCreateProperSerializationWithSaneDefaults() throws Exception {
         final JacksonJsonConverter<Entity> converter = JacksonJsonConverter.getInstanceWithSaneDefaults();
 
         Assert.assertThat(converter.getStringForm(entity), CoreMatchers.equalTo(
-                "{\n" +
-                "  \"age\" : 10,\n" +
-                "  \"date\" : \"1970-01-01T00:00:00.000+0000\"\n" +
-                "}")
+                "{\n  \"age\" : 10,\n  \"firstName\" : \"Tom\",\n  \"homeTown\" : \"Washington\",\n  \"lastName\" : \"Smith\"\n}")
         );
+    }
+
+    @Test
+    public void shouldSerializeEmptyWithSaneDefaults() throws Exception {
+        final JacksonJsonConverter<Entity> converter = JacksonJsonConverter.getInstanceWithSaneDefaults();
+        entity = new Entity();
+        Assert.assertThat(converter.getStringForm(entity), CoreMatchers.equalTo("{\n  \"age\" : 0\n}"));
     }
 
     @Test
@@ -58,7 +65,7 @@ public class JacksonJsonConverterTest {
         final JacksonJsonConverter<Entity> converter = JacksonJsonConverter.getInstanceWithObjectMapper(new ObjectMapper());
         final String stringForm = converter.getStringForm(entity);
 
-        Assert.assertThat(stringForm, CoreMatchers.equalTo("{\"date\":0,\"name\":null,\"age\":10}"));
+        Assert.assertThat(stringForm, CoreMatchers.equalTo("{\"date\":0,\"firstName\":\"Tom\",\"lastName\":\"Smith\",\"age\":10,\"homeTown\":\"Washington\"}"));
     }
 
 
@@ -74,5 +81,23 @@ public class JacksonJsonConverterTest {
 
         final JacksonJsonConverter<Entity> converter = JacksonJsonConverter.getInstanceWithObjectMapper(objectMapper);
         final String stringForm = converter.getStringForm(entity);
+    }
+
+    @Test
+    public void shouldIgnoreAgeDateFirstNameBasedOnJacksonMixinInfo() {
+        final JacksonJsonConverter<Entity> converter = JacksonJsonConverter.getInstanceWithObjectMapper(new ObjectMapper());
+        converter.withJacksonMixin(entity.getClass(), EntityMixin1.class);
+        final String stringForm = converter.getStringForm(entity);
+
+        Assert.assertThat(stringForm, CoreMatchers.equalTo("{\"lastName\":\"Smith\",\"homeTown\":\"Washington\"}"));
+    }
+
+    @Test
+    public void shouldIgnoreLastNameHometownBasedOnJacksonMixinInfo() {
+        final JacksonJsonConverter<Entity> converter = JacksonJsonConverter.getInstanceWithObjectMapper(new ObjectMapper());
+        converter.withJacksonMixin(entity.getClass(), EntityMixin2.class);
+        final String stringForm = converter.getStringForm(entity);
+
+        Assert.assertThat(stringForm, CoreMatchers.equalTo("{\"date\":0,\"firstName\":\"Tom\",\"age\":10}"));
     }
 }


### PR DESCRIPTION
The goal is to ignore different fields of the entity to be tested in order
for them not to appear in the final JSON string representation in the
approval process.