### PR TITLE
Refrain from deleting initial approval file to allow user to review contents

### DIFF
--- a/approval-core/src/main/java/com/github/approval/Approval.java
+++ b/approval-core/src/main/java/com/github/approval/Approval.java
@@ -219,8 +219,6 @@ public class Approval<T> {
     private void handleFirstTimeApproval(File file, Path approvalPath, byte[] rawValue) {
         try {
             fileSystemReadWriter.write(approvalPath, rawValue);
-
-            approvalPath.toFile().deleteOnExit();
         } catch (IOException e) {
             throw new AssertionError("Couldn't write path for approval " + approvalPath, e);
         }


### PR DESCRIPTION
Hi,

first of all thanks for your library, it has been very useful to me ever since.

I just realized that the initial approval doesn't behave as I thought it would. Looking closer, I find it strange to delete the initial ``forapproval`` files. I use a non-interactive approval scenario using a JUnit reporter. Thus, a failed approval means a failed test and the user is required to ``move`` the ``forapproval`` manually in order to use them as approval/master files. (I generate a shell/bat script for that purpose, so approval is a matter of running the script).

You can run the ``ExampleGoldenMasterTest`` in https://github.com/maxbechtold/golden-master to replay this use case. Note that currently, I require the user to run the tests a second time to get to the initial approval files. My idea is to provide the ``move`` script already on the first run, so the user can execute it once he reviewed the  ``forapproval`` files.

A word on testing: Cheers on your high coverage, although I struggle with the OS dependency of ``ApprovalTest`` (I mostly use Windows). I intended to adapt this one to check the ``forapproval`` files are kept, but don't see a simple solution since they are deleted only at the VM shutdown...